### PR TITLE
Minor update to README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The API will be running under the URL mentioned above.
 
 You should also be able to access the GraphiQL GraphQL Introspection UI under:
 
-[http://localhost:8081/graphiql](http://localhost:8081/graphql)
+[http://localhost:8081/graphiql](http://localhost:8081/graphiql)
 
 ###### Add image of GraphiQL UI here!
 

--- a/template/package.json
+++ b/template/package.json
@@ -26,9 +26,10 @@
   },
   "homepage": "http://quasar-framework.org",
   "dependencies": {
+    "body-parser": "^1.18.2",
     "express": "4.13.4",
-    "graphql-tools": "^0.11.0",
-    "graphql-server-express": "^0.6.0"
+    "graphql-server-express": "^0.6.0",
+    "graphql-tools": "^0.11.0"
   },
   "devDependencies": {
     "babel-cli": "6.5.1",


### PR DESCRIPTION
The README text below is correct:

"You should also be able to access the GraphiQL GraphQL Introspection UI
under:

http://localhost:8081/graphiql"

However, the link goes instead to http://localhost:8081/graphql instead
of http://localhost:8081/graphiql.

Also body-parser was not in package.json

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
